### PR TITLE
Force decrypt_kernel to use python2

### DIFF
--- a/bin/decrypt_kernel
+++ b/bin/decrypt_kernel
@@ -31,7 +31,7 @@ else
     warn_if_error
 fi
 
-lzss_offset=$(./get_lzss_section_offset.py "$kernelcache_decrypted")
+lzss_offset=$(python3 ./get_lzss_section_offset.py "$kernelcache_decrypted")
 
 debug "Unpacking kernelcache file $kernelcache_decrypted (offet $lzss_offset) to $kernelcache ..."
 debug "$LZSSDEC -o $lzss_offset < $kernelcache_decrypted > $kernelcache"

--- a/bin/get_lzss_section_offset.py
+++ b/bin/get_lzss_section_offset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import struct
@@ -10,7 +10,7 @@ def main():
         sys.exit(1)
 
     offset = 0
-    with open(sys.argv[1]) as f:
+    with open(sys.argv[1], 'rb') as f:
         found = False
         while True:
             buf = f.read(16)
@@ -19,11 +19,11 @@ def main():
             if len(buf) < 16:
                 break
             for i in range(0, 16):
-                if ord(buf[i]) == 0xff and i+4 < 16:
+                if buf[i] == 0xff and i+4 < 16:
                     chunk = struct.unpack("<I", buf[i+1:i+5])[0]
                     if chunk == 0xfeedface or chunk == 0xfeedfacf:
                         found = True
-                        print offset+i
+                        print(offset+i)
                         break
             if found == True:
                 break


### PR DESCRIPTION
Proposes a change to line 34 in bin/decrypt_kernel to explicitly use python2 when running get_lzss_section_offset.py script