### PR TITLE
Fixed mounting for OS X 10.15 Catalina

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -8,6 +8,9 @@ IPSW_STORE="$STORE"/ipsw
 # Where to store extracted and processed files.
 OUT_STORE="$STORE"/out
 
+# Where to mount root filesystem.
+MOUNT_DIR="$STORE"/mnt
+
 # Make scripts print out general information.
 INFO=1
 

--- a/scripts/common
+++ b/scripts/common
@@ -126,6 +126,10 @@ if [[ "$OUT_STORE" != /* ]]; then
     OUT_STORE=../"$OUT_STORE"
 fi
 
+if [[ "$MOUNT_DIR" != /* ]]; then
+    MOUNT_DIR=../"$MOUNT_DIR"
+fi
+
 out_dir="$OUT_STORE"/"$base"
 ipsw="$IPSW_STORE"/"$base"_Restore.ipsw
 

--- a/scripts/copy_sandboxd
+++ b/scripts/copy_sandboxd
@@ -2,7 +2,7 @@
 
 source common
 
-mount_point=/mnt/ios/"$base"
+mount_point=$(realpath "$MOUNT_DIR"/ios/"$base")
 if ! mount | grep -qs "$mount_point"; then
     error "No volume is mounted in $mount_point"
     exit 1

--- a/scripts/extract_dyld_shared_cache
+++ b/scripts/extract_dyld_shared_cache
@@ -7,7 +7,7 @@ if [[ $OSTYPE != darwin* ]]; then
     exit 1
 fi
 
-mount_point=/mnt/ios/"$base"
+mount_point=$(realpath "$MOUNT_DIR"/ios/"$base")
 if ! mount | grep -qs "$mount_point"; then
     error "No volume is mounted in $mount_point"
     exit 1

--- a/scripts/mount_fs
+++ b/scripts/mount_fs
@@ -23,8 +23,11 @@ else
     fi
 fi
 
-mount_point=/mnt/ios/"$base"
+mount_point="$MOUNT_DIR"/ios/"$base"
+
 mkdir -p "$mount_point"
+
+mount_point=$(realpath "$mount_point")
 if mount | grep -qs "$mount_point"; then
     error "A volume is already mounted in $mount_point"
     error "Unmount it first from $mount_point"

--- a/scripts/pack_filesystem
+++ b/scripts/pack_filesystem
@@ -7,7 +7,7 @@ if test $UID -ne 0; then
     exit 1
 fi
 
-mount_point=/mnt/ios/"$base"
+mount_point=$(realpath "$MOUNT_DIR"/ios/"$base")
 if ! mount | grep -qs "$mount_point"; then
     error "No volume is mounted in $mount_point"
     exit 1

--- a/scripts/unmount_fs
+++ b/scripts/unmount_fs
@@ -7,7 +7,7 @@ if test $UID -ne 0; then
     exit 1
 fi
 
-mount_point=/mnt/ios/"$base"
+mount_point=$(realpath "$MOUNT_DIR"/ios/"$base")
 if ! mount | grep -qs "$mount_point"; then
     error "No volume is mounted in $mount_point"
     exit 1


### PR DESCRIPTION
Fix for #10 

- **this assumes that users have added "coreutils" path (/opt/local/libexec/gnubin/) to their $PATH variable (as port install suggests)** 
- similar to OUT_STORE and IPSW, MOUNT_DIR can contain both an absolute or relative path, based on STORE variable
- mount_point was changed to absolute path because "mount" command lists absolute paths of mounted devices.