### PR TITLE
Add new firmware metadata file

### DIFF
--- a/firmware-metadata/iPhone6,2_11.0.0_15A372
+++ b/firmware-metadata/iPhone6,2_11.0.0_15A372
@@ -1,0 +1,5 @@
+firmware_keys_url: https://www.theiphonewiki.com/wiki/Tigris_15A372_(iPhone6,2)
+firmware_download_url: http://appldnld.apple.com/ios11.0/091-31853-201700919-35B5A2B8-9027-11E7-B85A-3435B64D2808/iPhone_4.0_64bit_11.0_15A372_Restore.ipsw
+rootfs_key:
+kernelcache_iv:
+kernelcache_key:


### PR DESCRIPTION
Add metadata file for iPhone 6,2_15A372 firmware, which supports iOS version 11.0.0.