### PR TITLE
updated scripts to use the new sandblaster helper script

### DIFF
--- a/scripts/sandblaster_extract_operations
+++ b/scripts/sandblaster_extract_operations
@@ -32,6 +32,6 @@ fi
 
 debug "Change working directory to ../tools/sandblaster/helpers/"
 cd ../tools/sandblaster/helpers/
-debug "./extract_sandbox_operations $sandbox_kext $version > $sb_ops"
-./extract_sandbox_operations "$sandbox_kext" "$version" > "$sb_ops" 2> /dev/null
+debug "./extract_sandbox_data.py -o "$sb_ops" "$sandbox_kext" "$version""
+./extract_sandbox_data.py -o "$sb_ops" "$sandbox_kext" "$version" 2> /dev/null
 warn_if_error

--- a/scripts/sandblaster_extract_profiles
+++ b/scripts/sandblaster_extract_profiles
@@ -46,6 +46,9 @@ fi
 
 debug "Change working directory to ../tools/sandblaster/helpers/"
 cd ../tools/sandblaster/helpers/
-debug "./extract_sandbox_profiles $binary_file $version $out_dir"
-./extract_sandbox_profiles "$binary_file" "$version" "$out_dir" > /dev/null 2>&1
+debug "./extract_sandbox_data.py -O . "$binary_file" "$version""
+./extract_sandbox_data.py -O . "$binary_file" "$version" 2> /dev/null
+
+# old sandblaster helper scripts created sandbox_bundle in $out_dir
+mv sandbox_bundle "$out_dir"
 warn_if_error

--- a/scripts/sandblaster_reverse_profiles
+++ b/scripts/sandblaster_reverse_profiles
@@ -18,8 +18,8 @@ call_reverse()
         profile=../../"$profile"
     fi
     debug "Reversing sandbox profile(s) from $profile to $dest ..."
-    debug "python reverse_sandbox.py -r $version -o $sb_ops -d $dest $profile 2> /dev/null"
-    python reverse_sandbox.py -r "$version" -o "$sb_ops" -d "$dest" "$profile" 2> /dev/null > /dev/null
+    debug "python2 reverse_sandbox.py -r "$version" -o "$sb_ops" -d "$dest" "$profile" 2> /dev/null"
+    python2 reverse_sandbox.py -r "$version" -o "$sb_ops" -d "$dest" "$profile" 2> /dev/null
     warn_if_error
 }
 


### PR DESCRIPTION
The scripts now call the new sandblaster script `extract_sandbox_data.py` and use `python2` for running reverse_sandbox.py.